### PR TITLE
chore(sem-release): move release info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,20 @@
     "request-promise-native": "^1.0.9",
     "sequelize": "^6.3.5",
     "sequelize-cli": "^6.2.0"
+  },
+  "release": {
+    "branches": ["main"],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/changelog",
+      [
+        "@semantic-release/npm",
+        { "npmPublish": false }
+      ],
+      "@semantic-release/github",
+      "@semantic-release/git"
+    ],
+    "tagFormat": "${version}"
   }
 }


### PR DESCRIPTION
Not sure why, but this way it works