### PR TITLE
chore(ci): update CircleCI orbs and images to latest versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,14 @@
 orbs:
-  codecov: codecov/codecov@4.1.0
-  docker: circleci/docker@2.7.1
-  node: circleci/node@6.1.0
-  shellcheck: circleci/shellcheck@3.2.0
-  slack: circleci/slack@4.13.3
+  codecov: codecov/codecov@5.4.3
+  node: circleci/node@7.2.1
+  shellcheck: circleci/shellcheck@3.4.0
+  slack: circleci/slack@6.1.2
 version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/node:20.17.0
-      - image: cimg/postgres:16.4
+      - image: cimg/node:20.19.6
+      - image: cimg/postgres:16.10
         environment:
           POSTGRES_PASSWORD: config.test.postgres.password
     parallelism: 4
@@ -30,7 +29,7 @@ jobs:
           path: ~/reports
   build:
     docker:
-      - image: cimg/base:2024.09
+      - image: cimg/base:2025.12
     resource_class: large
     steps:
       - checkout
@@ -39,7 +38,7 @@ jobs:
       - run: docker-compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml build --no-cache network
   eslint:
     docker:
-      - image: cimg/node:20.17.0
+      - image: cimg/node:20.19.6
     resource_class: large
     steps:
       - checkout
@@ -52,7 +51,7 @@ jobs:
           path: ~/reports
   yamllint:
     docker:
-      - image: cimg/python:3.12.6
+      - image: cimg/python:3.13.11
     resource_class: large
     steps:
       - checkout
@@ -60,15 +59,23 @@ jobs:
       - run: yamllint -d .yamllint.yml .
   shellcheck:
     docker:
-      - image: cimg/base:2024.09
+      - image: cimg/base:2025.12
     resource_class: large
     steps:
       - checkout
       - shellcheck/install
       - shellcheck/check
+  hadolint:
+    docker:
+      - image: hadolint/hadolint:latest-alpine
+    steps:
+      - checkout
+      - run:
+          name: Lint Dockerfiles
+          command: hadolint $(find . -name '*Dockerfile*')
   audit:
     docker:
-      - image: cimg/node:20.17.0
+      - image: cimg/node:20.19.6
     resource_class: large
     steps:
       - checkout
@@ -115,7 +122,7 @@ jobs:
               }
   docker-build-and-push:
     docker:
-      - image: cimg/node:20.17.0
+      - image: cimg/node:20.19.6
     resource_class: large
     steps:
       - checkout
@@ -216,8 +223,7 @@ workflows:
       - eslint
       - yamllint
       - shellcheck
-      - docker/hadolint:
-          dockerfiles: $(find . -name '*Dockerfile*')
+      - hadolint
   build:
     jobs:
       - build:


### PR DESCRIPTION
## Summary
- Update codecov orb: 4.1.0 → 5.4.3
- Update node orb: 6.1.0 → 7.2.1
- Update shellcheck orb: 3.2.0 → 3.4.0
- Update slack orb: 4.13.3 → 6.1.2
- Remove docker orb, add dedicated hadolint job
- Update cimg/node: 20.17.0 → 20.19.6
- Update cimg/postgres: 16.4 → 16.10
- Update cimg/base: 2024.09 → 2025.12
- Update cimg/python: 3.12.6 → 3.13.11

## Test plan
- [ ] Verify CircleCI builds pass with new versions

🤖 Generated with [Claude Code](https://claude.ai/code)